### PR TITLE
Docker checksum

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -10,8 +10,12 @@ source "${CURRENT_PATH}/support/sh/functions/cic_docker.sh"
 
 if ! which docker
 then
-    say "$(ok "Installing docker")"
-    bash "${CURRENT_PATH}/support/sh/install_docker_ubuntu.sh"
+    say "$(error "Install docker")"
+elif ! docker version > /dev/null 2>&1
+then
+    say "$(error "Docker command not working!")"
+    say "Ensure docker is installed and your user has the correct permissions. I.e. you're able to run: docker version"
+    exit 1
 fi
 
 say "$(ok "Fetching course images from dockerhub")"


### PR DESCRIPTION
Whilst working with @TheWonn on reviewing CIC content. We attempted to setup the project on their machine. The setup script failed because their user was not part of the Docker group and so did not have the permissions required to pull the course image.

The setup script had skipped over the installation of Docker because their machine already had docker installed.

We used line in the [install_docker_ubuntu.sh](https://github.com/lvl-up/ci-cd-training/blob/e242201975be0c0a7e3a4bd1b06d474c62d8e71d/bin/support/sh/install_docker_ubuntu.sh#L22) script that adds the user to the docker group however we were still required to logout and login again in order for the changes to take affect. This was unexpected, due to the command used was supposed to avoid the need for this, but maybe down to the fact we were using Linux Mint?

In any case this has again raised the point as to whether we should try and install docker on behalf of the participant or whether we should point them towards them the installation instructions for all distros.

Given we are using docker and the only other requirements for a participant machines are git and bash it makes sense that users will attempt to use their own machine/choice of O/S so expect this issue to keep happening.

In this pull request I have:
- attempted to tighten the checking for whether docker is installed and configured sufficiently
- removed the call to the install_docker_unbuntu.sh script. Hopefully this isn't to controversial. I think we should be as helpful as possible however I think we need avoid the cost of trying to produce comprehensive installation docs or supporting installation scripts for all scenarios. Hopefully our approach of minimising the requirements on a host machine will mean that setting up a host machine is easy for the participant.