### PR TITLE
task to generate all content

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,6 +16,6 @@ task :clean do
   FileUtils.rm_rf("#{__dir__}/coverage")
 end
 
-default_tasks = %i[clean spec generate_exercises rubocop shellcheck coverage_check]
+default_tasks = %i[clean spec generate_course_content rubocop shellcheck coverage_check]
 desc default_tasks.join(',')
 task default: default_tasks

--- a/tasks/exercises.rake
+++ b/tasks/exercises.rake
@@ -1,9 +1,10 @@
 desc 'generate project exercises from .templates/*.erb templates'
-task :generate_exercises, :mode do |_task, args|
+task :generate_course_content, :mode do |_task, args|
   flag = args[:mode] == 'verbose' ? '' : '--quiet'
   result = true
   root_dir = File.expand_path("#{__dir__}/..")
-  Dir["#{root_dir}/exercises/**/.templates"].each do |templates_dir|
+
+  Dir["#{root_dir}/**/.templates"].each do |templates_dir|
     exercise_dir = File.expand_path("#{templates_dir}/..")
     pretty_exercise_path = exercise_dir.gsub(root_dir, '').gsub(%r{^/}, '')
     exercise_command = "exercise generate #{flag} --pretty-exercise-path=#{pretty_exercise_path}"


### PR DESCRIPTION
generate_exercises has been changed to generate_course_content and now generates content found in .templates directories in the whole project as opposed to just in the exercises directory. This covers the main project README and fixes #67 